### PR TITLE
무제한모드 버그 수정/세이브 변수 추가

### DIFF
--- a/Assets/Scripts/SundayScene/panelScript.cs
+++ b/Assets/Scripts/SundayScene/panelScript.cs
@@ -19,13 +19,20 @@ public class panelScript : MonoBehaviour
 
         if(successEvent.isClear) { //빚을 갚은 상태일 때
 
+            Debug.Log("성공횟수:"+successEvent.ClearNum);
+
             foreach(int week in churchManager.chDay){
-                if (successEvent.ClearNum == chDay[chDay.Length - 1]){
+                if(successEvent.ClearNum > chDay[chDay.Length - 1]){ // 엔딩 이후
+                    scsPanel.SetActive(false); // 성공여부 팝업을 닫음
+                    SceneManager.LoadScene("eventScene");
+                    break;
+                }
+                else if (successEvent.ClearNum == chDay[chDay.Length - 1]){
                     scsPanel.SetActive(false); // 성공여부 팝업을 닫고
                     edPanel.SetActive(true); // 엔딩 팝업을 오픈
                     break;
                 }
-                if(successEvent.ClearNum == week){ //레벨업하는 주차
+                else if(successEvent.ClearNum == week){ //레벨업하는 주차
                     scsPanel.SetActive(false); // 성공여부 팝업을 닫고
                     lvUpPanel.SetActive(true); // 레벨업 팝업을 오픈
                     break;

--- a/Assets/Scripts/ending/openClearMode.cs
+++ b/Assets/Scripts/ending/openClearMode.cs
@@ -9,6 +9,9 @@ public class openClearMode : MonoBehaviour
     {
         // 게임을 클리어시 gameClear 변수를 true로 설정 (무제한 모드용)
         gameManager.gameClear = true;
+        dateManager.dateNum ++; // 월요일로 넘기기 위해!! 
+        dateManager.weekNum ++;
+        gameManager.Save();
         
     }
     

--- a/Assets/Scripts/gameManager.cs
+++ b/Assets/Scripts/gameManager.cs
@@ -25,6 +25,8 @@ public class saveData
     public bool decideDebt;
     public bool gameClear; // 게임 1회차 클리어 여부 저장(지현)
 
+    public int ClearNum; 
+
 
 }
 public class gameManager : MonoBehaviour
@@ -53,6 +55,7 @@ public class gameManager : MonoBehaviour
         //***추가된 변수들(지현)
         tutorialManager.mgTutorial = true; // 미니게임 튜토리얼 표시 여부
         gameManager.gameClear = false; // 게임 1회차 클리어 여부 저장(지현)
+        successEvent.ClearNum = 0; // 건물 증축 성공 횟수
        
     }
      
@@ -70,7 +73,7 @@ public class gameManager : MonoBehaviour
      
         DontDestroyOnLoad(gameObject);
 
-        if(gameClear) gameRetry = 7; // 1회차 이상은 미니게임 무제한으로 가능 (7일에 7번까지)
+        //if(gameClear) gameRetry = 7; // 1회차 이상은 미니게임 무제한으로 가능 (7일에 7번까지)
         
         DayValues(); // 게임 날짜 관리
         MiniValues(); // 미니게임 난이도 관리
@@ -144,7 +147,7 @@ public class gameManager : MonoBehaviour
         saveData data = new saveData();
 
         //저장값들을 전부 초기값으로 설정 
-        data.beanNum = 250; // 보유 콩 개수
+        data.beanNum = 25000000; // 보유 콩 개수
         data.diceNum = 10; // 보유 주사위 개수
         data.birdNum = 1; // 보유 신도 수
         data.dateNum = -1; // 게임상의 날짜
@@ -163,6 +166,8 @@ public class gameManager : MonoBehaviour
         data.weekNum = 0; // week: n주차
         data.gameRetry = 3; //미니게임 가능 횟수 
         data.decideDebt = false;
+        data.gameClear = false; // 게임 클리어 여부(지현)
+        data.ClearNum = 0; // 증축 성공 횟수(지현)
 
         File.WriteAllText(Application.persistentDataPath + "/clearInfo.json", JsonUtility.ToJson(data));
         //Debug.Log("저장 파일 생성!");
@@ -202,6 +207,7 @@ public class gameManager : MonoBehaviour
         dateManager.decideDebt = data.decideDebt;
 
         gameManager.gameClear = data.gameClear; // 추가(지현)
+        successEvent.ClearNum = data.ClearNum; // 추가(지현)
 
     }
     //세이브 함수 
@@ -224,6 +230,7 @@ public class gameManager : MonoBehaviour
         }
         data.tutorial = tutorialManager.tutorial; // 지현
         data.gameClear = gameManager.gameClear; // 지현
+        data.ClearNum = successEvent.ClearNum; // 지현
         data.startpanelSee= data.startpanelSee;
 
         data.weekNum= dateManager.weekNum;  

--- a/Assets/Scripts/introScene/IntroUI.cs
+++ b/Assets/Scripts/introScene/IntroUI.cs
@@ -10,6 +10,14 @@ public class IntroUI : MonoBehaviour
     public GameObject Panel;
     public static bool startpanelSee = true;
     public void StartClick(){
+
+
+        Debug.Log(gameManager.gameClear);
+        
+        // if(gameManager.gameClear){ // 엔딩 봤으면 일요일 -> 월요일
+        //     SceneManager.LoadScene("eventScene");
+        // }
+
         if(startpanelSee)  //첫플레이면 안내 패널을 띄우고
             Panel.SetActive(true);
         //저장 파일이 있는 상태면 바로 메인으로
@@ -35,7 +43,9 @@ public class IntroUI : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        Debug.Log("시작");
+        if(gameManager.gameClear) gameManager.gameRetry = 7; // 1회차 이상은 미니게임 무제한으로 가능 (7일에 7번까지)
+        else gameManager.gameRetry = 3;
     }
 
     // Update is called once per frame


### PR DESCRIPTION
### 무제한모드 버그 수정
- 무제한모드를 위한 변수가 세이브 함수에 없어서 오류가 생겼음
- 엔딩씬에 세이브 기능을 넣어서 엔딩 이후에도 오류 해결
- 세이브 함수에 변수 추가: `ClearNum` (건물 증축 성공 횟수 저장)

### 참고
- 엔딩을 본 이후에는 리셋해도 무제한 모드가 유지됨
- `엔딩` -> `리셋` -> `게임종료` -> `다시시작` 하면 무제한모드 해제됨